### PR TITLE
Remove young hacker clause

### DIFF
--- a/children.rst
+++ b/children.rst
@@ -1,9 +1,8 @@
-Young Hackers & Children
+Children
 ========
-Young adults aged between 16 and 18 can join the Hackspace as 'Young Hackers'. The guidance for this is available on request, the key thing to note being that their parents or guardians will need to meet with a Trustee at the Hackspace to discuss the risks within the Space. If you know of someone interested in becoming a Young Hacker, please ask them to contact the `Membership team`__.
 
 Children are welcome at Nottinghack, however be aware that it is primarily an adult environment. While it is unlikely that there would be content overtly unsuitable for children, members may not be watching their language or could be discussing adult topics. In addition to this; the Hackspace has potentially dangerous tools and chemicals which are not locked away, and no specific child-proofing measures in place.
 
-**Under-16s, and 16-18 year olds who are not 'Young Hackers', must be accompanied by an adult**, and are generally expected to be engaged with the space some way (such as working on a project). Periodically we have events specifically for children of all ages.
+**Under-16s, and 16-18 year olds must be accompanied by an adult**, and are generally expected to be engaged with the space some way (such as working on a project). Periodically we have events specifically for children of all ages.
 
 .. __: mailto:membership@nottinghack.org.uk


### PR DESCRIPTION
Trustees voted to end young hacker memberships at the 18th June 2019 meeting