### PR TITLE
clarify lps contact info, plus small punctuation edit

### DIFF
--- a/storage.rst
+++ b/storage.rst
@@ -1,7 +1,7 @@
 Storage
 =======
 
-The Hackspace has two storage areas for keeping your projects while they're worked on; member-owned storage boxes for smaller projects and components, and the Large Project Shelves (LPS) for projects which need a little more space. Please do not store projects anywhere else in the Hackspace, we have a lot of members and a fixed amonut of space meaning we've got lots to cram in. If you have an oversized project that will not fit on the LPS then please ask on the Google Group before bringing it in.
+The Hackspace has two storage areas for keeping your projects while they're worked on: member-owned storage boxes for smaller projects and components, and the Large Project Shelves (LPS) for projects which need a little more space. Please do not store projects anywhere else in the Hackspace, we have a lot of members and a fixed amonut of space meaning we've got lots to cram in. If you have an oversized project that will not fit on the LPS then please ask the trustees before bringing it in.
 
 Any projects outside of a storage box that is not being worked on should be removed from the space, to free up room for other projects to be worked on by other members.
 


### PR DESCRIPTION
contact trustees instead of google group.

also changed ; to : in the first sentence since it's preceding a list instead of joining two main clauses.